### PR TITLE
Improve options support

### DIFF
--- a/examples/options.rs
+++ b/examples/options.rs
@@ -20,21 +20,21 @@ fn main() {
 				println!(" {}({:?}) - {:?}", asdf.name(), asdf.default_value(), asdf.help());
 			})
 		});
+	});
 
-		output::all().for_each(|output| {
-			println!("\n\noutput: {}\n", output.name());
-			output.options().for_each(|option| {
-				println!(
-					"{}({:?} - {:?}): {:?}",
-					option.name(),
-					option.kind(),
-					option.default_value(),
-					option.help()
-				);
-				option.constants().for_each(|asdf| {
-					println!(" {}({:?}) - {:?}", asdf.name(), asdf.default_value(), asdf.help());
-				})
-			});
+	output::all().for_each(|output| {
+		println!("\n\noutput: {}\n", output.name());
+		output.options().for_each(|option| {
+			println!(
+				"{}({:?} - {:?}): {:?}",
+				option.name(),
+				option.kind(),
+				option.default_value(),
+				option.help()
+			);
+			option.constants().for_each(|asdf| {
+				println!(" {}({:?}) - {:?}", asdf.name(), asdf.default_value(), asdf.help());
+			})
 		});
 	});
 }

--- a/examples/options.rs
+++ b/examples/options.rs
@@ -16,8 +16,13 @@ fn main() {
 				option.default_value(),
 				option.help()
 			);
-			option.constants().for_each(|asdf| {
-				println!(" {}({:?}) - {:?}", asdf.name(), asdf.default_value(), asdf.help());
+			option.constants().for_each(|constant| {
+				println!(
+					" {}({:?}) - {:?}",
+					constant.name(),
+					constant.default_value(),
+					constant.help()
+				);
 			})
 		});
 	});
@@ -32,8 +37,13 @@ fn main() {
 				option.default_value(),
 				option.help()
 			);
-			option.constants().for_each(|asdf| {
-				println!(" {}({:?}) - {:?}", asdf.name(), asdf.default_value(), asdf.help());
+			option.constants().for_each(|constant| {
+				println!(
+					" {}({:?}) - {:?}",
+					constant.name(),
+					constant.default_value(),
+					constant.help()
+				);
 			})
 		});
 	});

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -101,7 +101,12 @@ impl Codec {
 
 	pub fn options(&self) -> OptionIter {
 		let ptr = (unsafe { *self.as_ptr() }).priv_class;
-		OptionIter::new(ptr)
+		let flags = if self.is_encoder() {
+			sys::AV_OPT_FLAG_ENCODING_PARAM
+		} else {
+			sys::AV_OPT_FLAG_DECODING_PARAM
+		};
+		OptionIter::new(ptr, flags)
 	}
 }
 

--- a/src/codec/codec.rs
+++ b/src/codec/codec.rs
@@ -1,5 +1,7 @@
 use std::{ffi::CStr, str::from_utf8_unchecked};
 
+use libc::c_void;
+
 use super::{Audio, Capabilities, Id, Profile, Video};
 use crate::{ffi::*, media, option::OptionIter, Error};
 
@@ -100,7 +102,7 @@ impl Codec {
 	}
 
 	pub fn options(&self) -> OptionIter {
-		let ptr = (unsafe { *self.as_ptr() }).priv_class;
+		let ptr = unsafe { (*self.as_ptr()).priv_class as *const c_void };
 		let flags = if self.is_encoder() {
 			sys::AV_OPT_FLAG_ENCODING_PARAM
 		} else {

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, ptr, rc::Rc};
 
-use libc::c_int;
+use libc::{c_int, c_void};
 
 #[cfg(feature = "ffmpeg_3_1")]
 use super::Parameters;
@@ -150,7 +150,7 @@ impl Context {
 	}
 
 	pub fn option(&self, option: &crate::option::Option) -> Option<OptionType> {
-		unsafe { get_option((*self.as_ptr()).priv_data, option) }
+		unsafe { get_option(self.as_ptr() as *mut c_void, option) }
 	}
 }
 

--- a/src/format/context/common.rs
+++ b/src/format/context/common.rs
@@ -1,6 +1,6 @@
 use std::{fmt, mem, ptr, rc::Rc};
 
-use libc::{c_int, c_uint};
+use libc::{c_int, c_uint, c_void};
 
 use super::destructor::{self, Destructor};
 use crate::{
@@ -135,7 +135,7 @@ impl Context {
 	}
 
 	pub fn option(&self, option: &crate::option::Option) -> Option<OptionType> {
-		unsafe { get_option((*self.as_ptr()).priv_data, option) }
+		unsafe { get_option(self.as_ptr() as *mut c_void, option) }
 	}
 }
 

--- a/src/format/format/input.rs
+++ b/src/format/format/input.rs
@@ -57,7 +57,7 @@ impl Input {
 
 	pub fn options(&self) -> OptionIter {
 		let ptr = (unsafe { *self.as_ptr() }).priv_class;
-		OptionIter::new(ptr)
+		OptionIter::new(ptr, sys::AV_OPT_FLAG_DECODING_PARAM)
 	}
 }
 

--- a/src/format/format/input.rs
+++ b/src/format/format/input.rs
@@ -56,7 +56,7 @@ impl Input {
 	}
 
 	pub fn options(&self) -> OptionIter {
-		let ptr = (unsafe { *self.as_ptr() }).priv_class;
+		let ptr = (unsafe { *self.as_ptr() }).priv_class as *const std::ffi::c_void;
 		OptionIter::new(ptr, sys::AV_OPT_FLAG_DECODING_PARAM)
 	}
 }

--- a/src/format/format/output.rs
+++ b/src/format/format/output.rs
@@ -82,7 +82,7 @@ impl Output {
 
 	pub fn options(&self) -> OptionIter {
 		let ptr = (unsafe { *self.as_ptr() }).priv_class;
-		OptionIter::new(ptr)
+		OptionIter::new(ptr, sys::AV_OPT_FLAG_ENCODING_PARAM)
 	}
 }
 

--- a/src/format/format/output.rs
+++ b/src/format/format/output.rs
@@ -81,7 +81,7 @@ impl Output {
 	}
 
 	pub fn options(&self) -> OptionIter {
-		let ptr = (unsafe { *self.as_ptr() }).priv_class;
+		let ptr = (unsafe { *self.as_ptr() }).priv_class as *const std::ffi::c_void;
 		OptionIter::new(ptr, sys::AV_OPT_FLAG_ENCODING_PARAM)
 	}
 }

--- a/src/util/option/iter.rs
+++ b/src/util/option/iter.rs
@@ -1,20 +1,28 @@
+use std::ffi::c_int;
+
 use sys::{av_opt_next, AVClass, AVOption};
 
 pub struct AVOptionIterator {
 	av_class: *const AVClass,
 	option: *const AVOption,
+	pub(crate) flags: c_int,
 }
 
 impl AVOptionIterator {
-	pub fn new(av_class: *const AVClass) -> Self {
+	pub fn new(av_class: *const AVClass, flags: c_int) -> Self {
 		Self {
 			av_class,
 			option: std::ptr::null(),
+			flags,
 		}
 	}
 
-	pub fn from_option(av_class: *const AVClass, option: *const AVOption) -> Self {
-		Self { av_class, option }
+	pub fn from_option(av_class: *const AVClass, option: *const AVOption, flags: c_int) -> Self {
+		Self {
+			av_class,
+			option,
+			flags,
+		}
 	}
 
 	pub fn class(&self) -> *const AVClass {
@@ -28,7 +36,13 @@ impl Iterator for AVOptionIterator {
 	fn next(&mut self) -> std::option::Option<<Self as Iterator>::Item> {
 		unsafe {
 			let priv_class = &self.av_class as *const *const AVClass;
-			let ptr = av_opt_next(priv_class as *const std::ffi::c_void, self.option);
+			let mut ptr = av_opt_next(priv_class as *const std::ffi::c_void, self.option);
+
+			// Skip while the flags aren't set and we haven't reached the end
+			while !ptr.is_null() && (*ptr).flags & self.flags == 0 {
+				ptr = av_opt_next(priv_class as *const std::ffi::c_void, self.option);
+				self.option = ptr;
+			}
 
 			if ptr.is_null() {
 				None

--- a/src/util/option/iter.rs
+++ b/src/util/option/iter.rs
@@ -3,30 +3,30 @@ use std::ffi::c_int;
 use sys::{av_opt_next, AVClass, AVOption};
 
 pub struct AVOptionIterator {
-	av_class: *const AVClass,
+	obj: *const std::ffi::c_void,
 	option: *const AVOption,
 	pub(crate) flags: c_int,
 }
 
 impl AVOptionIterator {
-	pub fn new(av_class: *const AVClass, flags: c_int) -> Self {
+	pub fn new(av_class: *const std::ffi::c_void, flags: c_int) -> Self {
 		Self {
-			av_class,
+			obj: av_class,
 			option: std::ptr::null(),
 			flags,
 		}
 	}
 
-	pub fn from_option(av_class: *const AVClass, option: *const AVOption, flags: c_int) -> Self {
+	pub fn from_option(av_class: *const std::ffi::c_void, option: *const AVOption, flags: c_int) -> Self {
 		Self {
-			av_class,
+			obj: av_class,
 			option,
 			flags,
 		}
 	}
 
-	pub fn class(&self) -> *const AVClass {
-		self.av_class
+	pub fn class(&self) -> *const std::ffi::c_void {
+		self.obj
 	}
 }
 
@@ -35,7 +35,7 @@ impl Iterator for AVOptionIterator {
 
 	fn next(&mut self) -> std::option::Option<<Self as Iterator>::Item> {
 		unsafe {
-			let priv_class = &self.av_class as *const *const AVClass;
+			let priv_class = &self.obj as *const *const std::ffi::c_void;
 			let mut ptr = av_opt_next(priv_class as *const std::ffi::c_void, self.option);
 
 			// Skip while the flags aren't set and we haven't reached the end

--- a/src/util/option/mod.rs
+++ b/src/util/option/mod.rs
@@ -125,14 +125,14 @@ impl OptionConstant {
 }
 
 pub struct Option {
-	class: *const AVClass,
+	obj: *const std::ffi::c_void,
 	option: *const AVOption,
 	flags: c_int,
 }
 
 impl Option {
-	pub fn new(class: *const AVClass, option: *const AVOption, flags: c_int) -> Self {
-		Self { class, option, flags }
+	pub fn new(obj: *const std::ffi::c_void, option: *const AVOption, flags: c_int) -> Self {
+		Self { obj, option, flags }
 	}
 }
 
@@ -162,12 +162,12 @@ impl Option {
 	}
 
 	pub fn constants(&self) -> impl Iterator<Item = OptionConstant> + '_ {
-		AVOptionIterator::from_option(self.class, self.option, self.flags)
+		AVOptionIterator::from_option(self.obj, self.option, self.flags)
 			.take_while(|option| {
 				let option = *option;
 				(unsafe { *option }).type_ == AV_OPT_TYPE_CONST
 			})
-			.map(|option| OptionConstant(Option::new(self.class, option, self.flags)))
+			.map(|option| OptionConstant(Option::new(self.obj, option, self.flags)))
 	}
 
 	pub fn default_value(&self) -> OptionType {
@@ -212,9 +212,9 @@ pub struct OptionIter {
 }
 
 impl OptionIter {
-	pub fn new(class: *const AVClass, flags: c_int) -> Self {
+	pub fn new(obj: *const std::ffi::c_void, flags: c_int) -> Self {
 		Self {
-			inner: AVOptionIterator::new(class, flags),
+			inner: AVOptionIterator::new(obj, flags),
 		}
 	}
 }
@@ -243,7 +243,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 	match option.kind() {
 		Type::Flags | Type::Int | Type::Int64 | Type::Constant | Type::Duration | Type::ChannelLayout | Type::c_ulong => {
 			let mut value = 0;
-			let res = unsafe { av_opt_get_int(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get_int(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;
@@ -254,7 +254,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 
 		Type::Double | Type::Float => {
 			let mut value = 0.0;
-			let res = unsafe { av_opt_get_double(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get_double(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;
@@ -264,7 +264,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 		}
 		Type::String | Type::Binary | Type::ImageSize | Type::Dictionary | Type::Color | Type::VideoRate => {
 			let mut value = ptr::null_mut();
-			let res = unsafe { av_opt_get(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;
@@ -280,7 +280,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 		}
 		Type::Rational => {
 			let mut value = AVRational { num: 0, den: 1 };
-			let res = unsafe { av_opt_get_q(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get_q(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;
@@ -291,7 +291,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 
 		Type::PixelFormat => {
 			let mut value = AVPixelFormat::AV_PIX_FMT_NONE;
-			let res = unsafe { av_opt_get_pixel_fmt(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get_pixel_fmt(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;
@@ -301,7 +301,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 		}
 		Type::SampleFormat => {
 			let mut value = AVSampleFormat::AV_SAMPLE_FMT_NONE;
-			let res = unsafe { av_opt_get_sample_fmt(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get_sample_fmt(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;
@@ -312,7 +312,7 @@ pub unsafe fn get_option(ptr: *mut c_void, option: &crate::option::Option) -> st
 
 		Type::bool => {
 			let mut value = 0;
-			let res = unsafe { av_opt_get_int(ptr, name.as_ptr(), 0, &mut value) };
+			let res = unsafe { av_opt_get_int(ptr, name.as_ptr(), sys::AV_OPT_SEARCH_CHILDREN, &mut value) };
 
 			if res < 0 {
 				return None;


### PR DESCRIPTION
Only show options for "encoding" on output and vice versa and include AV_OPT_SEARCH_CHILDREN when searching for configured options. This ensures that libav looks at all relevant places when searching for a specific option. The options iterator now takes a void pointer because it doesn't always get an AVClass.