### PR TITLE
fix invalid str getting returned after ffmpeg 6.x

### DIFF
--- a/src/util/channel_layout.rs
+++ b/src/util/channel_layout.rs
@@ -257,7 +257,7 @@ impl ChannelLayout {
 
 				if bytes_needed <= buf.len() {
 					let s = String::from_utf8_lossy(&buf[..bytes_needed]);
-					Ok(Ok(s.into_owned()))
+					Ok(Ok(s.trim_end_matches('\0').to_string()))
 				} else {
 					Ok(Err(bytes_needed))
 				}


### PR DESCRIPTION
ChannelLayout::describe returns extra null terminator after ffmpeg 6.x