### PR TITLE
Don't set nb to none

### DIFF
--- a/src/util/format/pixel.rs
+++ b/src/util/format/pixel.rs
@@ -609,8 +609,6 @@ impl From<AVPixelFormat> for Pixel {
 			AV_PIX_FMT_P016LE => Pixel::P016LE,
 			AV_PIX_FMT_P016BE => Pixel::P016BE,
 
-			AV_PIX_FMT_NB => Pixel::None,
-
 			#[cfg(feature = "ffmpeg_3_3")]
 			AV_PIX_FMT_D3D11 => Pixel::D3D11,
 			AV_PIX_FMT_GRAY9BE => Pixel::GRAY9BE,


### PR DESCRIPTION
AV_PIX_FMT_NB != AV_PIX_FMT_NONE and should not be mapped to that.

This causes issues if the compiled rust binary is linked to a different avutil lib with more pixel formats than what is defined in the one that we compiled against. In that case one of the added pixel formats (only the one that took the enum value of the NB) will be incorrectly mapped to None instead of being placed in the "OTHER" slot that we have defined in the Pixel enum.