### PR TITLE
Handle closures

### DIFF
--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -20,10 +20,7 @@ impl Destructor {
 impl Drop for Destructor {
 	fn drop(&mut self) {
 		unsafe {
-			if !(*self.ptr).interrupt_callback.opaque.is_null() {
-				let closure: Box<Box<dyn FnMut() -> bool>> = Box::from_raw((*self.ptr).interrupt_callback.opaque as *mut _);
-				drop(closure);
-			}
+			let opaque = (*self.ptr).interrupt_callback.opaque;
 
 			match self.mode {
 				Mode::Input => avformat_close_input(&mut self.ptr),
@@ -40,6 +37,11 @@ impl Drop for Destructor {
 
 					avformat_free_context(self.ptr);
 				}
+			}
+
+			if !opaque.is_null() {
+				let closure: Box<Box<dyn FnMut() -> bool>> = Box::from_raw(opaque as *mut _);
+				drop(closure);
 			}
 		}
 	}

--- a/src/format/context/destructor.rs
+++ b/src/format/context/destructor.rs
@@ -20,6 +20,11 @@ impl Destructor {
 impl Drop for Destructor {
 	fn drop(&mut self) {
 		unsafe {
+			if !(*self.ptr).interrupt_callback.opaque.is_null() {
+				let closure: Box<Box<dyn FnMut() -> bool>> = Box::from_raw((*self.ptr).interrupt_callback.opaque as *mut _);
+				drop(closure);
+			}
+
 			match self.mode {
 				Mode::Input => avformat_close_input(&mut self.ptr),
 				Mode::Output => {


### PR DESCRIPTION
Rust closures that capture context in rust will leak that context with the current interrupt implementation. This wraps it into another box and explicitly types it as `dyn FnMut()->bool` to properly drop the closure when closing. Based on https://stackoverflow.com/a/32270215.

Note that the destructor will blow up big time if the opaque pointer _isn't_ a box wrapped closure, but this works for our use cases.