### PR TITLE
Improve log formatting and improve conditional compilation

### DIFF
--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -4,13 +4,16 @@ use vsprintf::vsprintf;
 
 use crate::ffi::*;
 
-#[cfg(target_os = "macos")]
-unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_char, args: va_list) {
+#[cfg(any(target_os = "macos", target_arch = "aarch64"))]
+unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char, args: va_list) {
 	if av_log_get_level() <= level {
 		return;
 	};
 
-	let string = vsprintf(fmt, args).unwrap();
+	let Ok(string) = vsprintf(fmt, args) else {
+		return;
+	};
+
 	let string = string.trim();
 
 	match level {
@@ -23,13 +26,16 @@ unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_cha
 	};
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_char, args: *mut __va_list_tag) {
 	if av_log_get_level() <= level {
 		return;
 	};
 
-	let string = vsprintf(fmt, args).unwrap();
+	let Ok(string) = vsprintf(fmt, args) else {
+		return;
+	};
+
 	let string = string.trim();
 
 	match level {

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -1,4 +1,5 @@
 use libc::{c_char, c_int, c_void};
+use std::ffi::CStr;
 
 use vsprintf::vsprintf;
 
@@ -24,7 +25,8 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 	);
 
 	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
-		let string = std::str::from_utf8(line.as_ref()).unwrap_or_default();
+		let slice = CStr::from_ptr(fmt);
+		let string = slice.to_str().unwrap_or_default();
 		tracing::warn!("invalid log line: {}", string);
 		return;
 	};
@@ -61,7 +63,8 @@ unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_cha
 	);
 
 	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
-		let string = std::str::from_utf8(line.as_ref()).unwrap_or_default();
+		let slice = CStr::from_ptr(fmt);
+		let string = slice.to_str().unwrap_or_default();
 		tracing::warn!("invalid log line: {}", string);
 		return;
 	};

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -44,7 +44,7 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_char, args: *mut __va_list_tag) {
+unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char, args: *mut __va_list_tag) {
 	if av_log_get_level() <= level {
 		return;
 	};

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -10,7 +10,20 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 		return;
 	};
 
-	let Ok(string) = vsprintf(fmt, args) else {
+	let mut line: &mut [u8] = &mut [0; 1024];
+	let mut print_prefix = 0;
+
+	ffmpeg_sys::av_log_format_line(
+		ptr,
+		level,
+		fmt,
+		args,
+		line.as_mut_ptr() as *mut c_char,
+		line.len() as i32,
+		&mut print_prefix,
+	);
+
+	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
 		return;
 	};
 
@@ -32,7 +45,20 @@ unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_cha
 		return;
 	};
 
-	let Ok(string) = vsprintf(fmt, args) else {
+	let mut line: &mut [u8] = &mut [0; 1024];
+	let mut print_prefix = 0;
+
+	ffmpeg_sys::av_log_format_line(
+		ptr,
+		level,
+		fmt,
+		args,
+		line.as_mut_ptr() as *mut c_char,
+		line.len() as i32,
+		&mut print_prefix,
+	);
+
+	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
 		return;
 	};
 

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -25,8 +25,8 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 	);
 
 	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
-		let slice = CStr::from_ptr(fmt);
-		let string = slice.to_str().unwrap_or_default();
+		let string = CStr::from_ptr(fmt);
+		let string = string.to_str().unwrap_or_default();
 		tracing::warn!("invalid log line: {}", string);
 		return;
 	};
@@ -63,8 +63,8 @@ unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_cha
 	);
 
 	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
-		let slice = CStr::from_ptr(fmt);
-		let string = slice.to_str().unwrap_or_default();
+		let string = CStr::from_ptr(fmt);
+		let string = string.to_str().unwrap_or_default();
 		tracing::warn!("invalid log line: {}", string);
 		return;
 	};

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -19,11 +19,13 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 		fmt,
 		args,
 		line.as_mut_ptr() as *mut c_char,
-		line.len() as i32,
+		line.len() as c_int,
 		&mut print_prefix,
 	);
 
 	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
+		let string = std::str::from_utf8(line.as_ref()).unwrap_or_default();
+		tracing::warn!("invalid log line: {}", string);
 		return;
 	};
 
@@ -54,11 +56,13 @@ unsafe extern "C" fn callback(_ptr: *mut c_void, level: c_int, fmt: *const c_cha
 		fmt,
 		args,
 		line.as_mut_ptr() as *mut c_char,
-		line.len() as i32,
+		line.len() as c_int,
 		&mut print_prefix,
 	);
 
 	let Ok(string) = std::str::from_utf8(line.as_ref()) else {
+		let string = std::str::from_utf8(line.as_ref()).unwrap_or_default();
+		tracing::warn!("invalid log line: {}", string);
 		return;
 	};
 


### PR DESCRIPTION
Stop using vsprintf in favor of the default format line function from ffmpeg.

Add support for arm64 linux. It should use the same configuration as macOS.

