### PR TITLE
Fix missing windows bindings for log + more windows fixes

### DIFF
--- a/src/util/channel_layout.rs
+++ b/src/util/channel_layout.rs
@@ -709,10 +709,9 @@ mod serde {
 					order: num_order,
 					mask,
 					map,
-				}) => {	
+				}) => {
 					order = AVChannelOrder(num_order);
 					
-
 					match (order, mask, map) {
 						(AVChannelOrder::AV_CHANNEL_ORDER_CUSTOM, _, Some(map)) => {
 							u = ChannelData {

--- a/src/util/channel_layout.rs
+++ b/src/util/channel_layout.rs
@@ -58,14 +58,14 @@ pub enum Channel {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[repr(u32)]
+#[repr(i32)]
 #[cfg_attr(feature = "serde", derive(serde_derive::Serialize, serde_derive::Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_", rename_all = "kebab-case"))]
 pub enum ChannelOrder {
-	Unspecified = AVChannelOrder::AV_CHANNEL_ORDER_UNSPEC.0,
-	Native = AVChannelOrder::AV_CHANNEL_ORDER_NATIVE.0,
-	Custom = AVChannelOrder::AV_CHANNEL_ORDER_CUSTOM.0,
-	Ambisonic = AVChannelOrder::AV_CHANNEL_ORDER_AMBISONIC.0,
+	Unspecified = AVChannelOrder::AV_CHANNEL_ORDER_UNSPEC.0 as i32,
+	Native = AVChannelOrder::AV_CHANNEL_ORDER_NATIVE.0 as i32,
+	Custom = AVChannelOrder::AV_CHANNEL_ORDER_CUSTOM.0 as i32,
+	Ambisonic = AVChannelOrder::AV_CHANNEL_ORDER_AMBISONIC.0 as i32,
 }
 
 pub struct ChannelLayout(AVChannelLayout);
@@ -292,7 +292,7 @@ impl ChannelLayout {
 	}
 
 	pub fn set_order(&mut self, order: ChannelOrder) {
-		self.0.order = AVChannelOrder(order as u32);
+		self.0.order = AVChannelOrder(order as libc::c_int);
 	}
 
 	pub fn channels(&self) -> i32 {
@@ -641,7 +641,7 @@ mod serde {
 
 			// provide type hints in order to get compile-time errors if ffmpeg
 			// changes the struct definition
-			s.serialize_field::<u32>("order", &self.0.order.0)?;
+			s.serialize_field::<libc::c_int>("order", &self.0.order.0)?;
 
 			if let Some(custom) = self.custom_channels() {
 				s.serialize_field("map", &custom)?;
@@ -667,7 +667,7 @@ mod serde {
 			#[derive(Deserialize)]
 			#[serde(crate = "serde_")]
 			struct NewLayout {
-				order: u32,
+				order: libc::c_int,
 
 				mask: Option<u64>,
 				map: Option<Vec<CustomChannel>>,

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -6,7 +6,7 @@ use vsprintf::vsprintf;
 use crate::ffi::*;
 use crate::sys::va_list;
 
-#[cfg(any(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_arch = "aarch64"))]
 unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char, args: va_list) {
 	if av_log_get_level() <= level {
 		return;
@@ -85,47 +85,6 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 		_ => {}
 	};
 }
-
-#[cfg(target_os = "windows")]
-unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char, args: va_list) {
-	if av_log_get_level() <= level {
-		return;
-	};
-
-	let mut line: &mut [u8] = &mut [0; 1024];
-	let mut print_prefix = 0;
-
-	let result = ffmpeg_sys::av_log_format_line2(
-		ptr,
-		level,
-		fmt,
-		args,
-		line.as_mut_ptr() as *mut c_char,
-		line.len() as c_int,
-		&mut print_prefix,
-	);
-
-	let line_length = (line.len() - 1).min(result as usize);
-
-	let Ok(string) = std::str::from_utf8(&line[..line_length]) else {
-		let string = CStr::from_ptr(fmt);
-		let string = string.to_str().unwrap_or_default();
-		tracing::warn!("invalid log line: {}", string);
-		return;
-	};
-
-	let string = string.trim();
-
-	match level {
-		AV_LOG_PANIC | AV_LOG_FATAL | AV_LOG_ERROR => tracing::error!("{string}"),
-		AV_LOG_WARNING => tracing::warn!("{string}"),
-		AV_LOG_INFO => tracing::info!("{string}"),
-		AV_LOG_VERBOSE | AV_LOG_DEBUG => tracing::debug!("{string}"),
-		AV_LOG_TRACE => tracing::trace!("{string}"),
-		_ => {}
-	};
-}
-
 
 pub fn register() {
 	unsafe {

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -4,6 +4,7 @@ use std::ffi::CStr;
 use vsprintf::vsprintf;
 
 use crate::ffi::*;
+use crate::sys::va_list;
 
 #[cfg(any(target_os = "macos", target_arch = "aarch64"))]
 unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char, args: va_list) {
@@ -84,6 +85,47 @@ unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char
 		_ => {}
 	};
 }
+
+#[cfg(target_os = "windows")]
+unsafe extern "C" fn callback(ptr: *mut c_void, level: c_int, fmt: *const c_char, args: va_list) {
+	if av_log_get_level() <= level {
+		return;
+	};
+
+	let mut line: &mut [u8] = &mut [0; 1024];
+	let mut print_prefix = 0;
+
+	let result = ffmpeg_sys::av_log_format_line2(
+		ptr,
+		level,
+		fmt,
+		args,
+		line.as_mut_ptr() as *mut c_char,
+		line.len() as c_int,
+		&mut print_prefix,
+	);
+
+	let line_length = (line.len() - 1).min(result as usize);
+
+	let Ok(string) = std::str::from_utf8(&line[..line_length]) else {
+		let string = CStr::from_ptr(fmt);
+		let string = string.to_str().unwrap_or_default();
+		tracing::warn!("invalid log line: {}", string);
+		return;
+	};
+
+	let string = string.trim();
+
+	match level {
+		AV_LOG_PANIC | AV_LOG_FATAL | AV_LOG_ERROR => tracing::error!("{string}"),
+		AV_LOG_WARNING => tracing::warn!("{string}"),
+		AV_LOG_INFO => tracing::info!("{string}"),
+		AV_LOG_VERBOSE | AV_LOG_DEBUG => tracing::debug!("{string}"),
+		AV_LOG_TRACE => tracing::trace!("{string}"),
+		_ => {}
+	};
+}
+
 
 pub fn register() {
 	unsafe {


### PR DESCRIPTION
Bindgen creates c_int vs c_uint on AvChannelOrder ffi binding depending on target, so we must handle it also.