### PR TITLE
Fix issue with adding more than 1 filter inputs

### DIFF
--- a/src/filter/graph.rs
+++ b/src/filter/graph.rs
@@ -185,9 +185,12 @@ impl<'a> Parser<'a> {
 
 			if self.outputs.is_null() {
 				self.outputs = output;
-			}
-			else {
-				(*self.outputs).next = output;
+			} else {
+				let mut tail = self.outputs;
+				while !(*tail).next.is_null() {
+					tail = (*tail).next;
+				}
+				(*tail).next = output;
 			}
 		}
 


### PR DESCRIPTION
# What

`outputs` is a linked list, so we cannot overwrite `next`, but should instead find the end of the list and add it there.

# Why

When building an filter graph, the old code would only allow adding two inputs.