### PR TITLE
Expose stream open with options

### DIFF
--- a/src/format/io.rs
+++ b/src/format/io.rs
@@ -7,9 +7,7 @@ use std::{
 use libc::{c_int, c_void, EINVAL, SEEK_CUR, SEEK_END, SEEK_SET};
 
 use crate::{
-	ffi::*,
-	format::{context, format},
-	Error,
+	Dictionary, Error, ffi::*, format::{context, format}
 };
 
 pub enum Proxy {
@@ -232,6 +230,24 @@ pub fn stream(io: impl Read + 'static) -> Result<context::Input, Error> {
 		(*ps).pb = io.as_mut_ptr();
 
 		match avformat_open_input(&mut ps, ptr::null_mut(), ptr::null_mut(), ptr::null_mut()) {
+			0 => Ok(context::Input::wrap_with(ps, io)),
+			e => Err(Error::from(e)),
+		}
+	}
+}
+
+pub fn stream_with_opts(io: impl Read + 'static, dictionary: Dictionary) -> Result<context::Input, Error> {
+	unsafe {
+		let mut ps = avformat_alloc_context();
+		let mut io = Io::stream(io);
+		(*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
+		(*ps).pb = io.as_mut_ptr();
+
+		let mut opts = dictionary.disown();
+		let res = avformat_open_input(&mut ps, ptr::null_mut(), ptr::null_mut(), &mut opts);
+		Dictionary::own(opts);
+
+		match res {
 			0 => Ok(context::Input::wrap_with(ps, io)),
 			e => Err(Error::from(e)),
 		}

--- a/src/format/io.rs
+++ b/src/format/io.rs
@@ -223,20 +223,14 @@ pub fn input(io: impl Read + Seek + 'static) -> Result<context::Input, Error> {
 }
 
 pub fn stream(io: impl Read + 'static) -> Result<context::Input, Error> {
-	unsafe {
-		let mut ps = avformat_alloc_context();
-		let mut io = Io::stream(io);
-		(*ps).flags |= AVFMT_FLAG_CUSTOM_IO;
-		(*ps).pb = io.as_mut_ptr();
-
-		match avformat_open_input(&mut ps, ptr::null_mut(), ptr::null_mut(), ptr::null_mut()) {
-			0 => Ok(context::Input::wrap_with(ps, io)),
-			e => Err(Error::from(e)),
-		}
-	}
+	open_stream(io, Dictionary::new())
 }
 
 pub fn stream_with_opts(io: impl Read + 'static, dictionary: Dictionary) -> Result<context::Input, Error> {
+	open_stream(io, dictionary)
+}
+
+fn open_stream(io: impl Read + 'static, dictionary: Dictionary) -> Result<context::Input, Error> {
 	unsafe {
 		let mut ps = avformat_alloc_context();
 		let mut io = Io::stream(io);


### PR DESCRIPTION
Previously we only exposed without possibility of setting options for `avformat_open_input` using `fn stream`
Now we can pass in `Dictionary` with the new `fn stream_with_opts`.